### PR TITLE
Small changes to speed up and reduce memory usage 

### DIFF
--- a/R/dummy_cols.R
+++ b/R/dummy_cols.R
@@ -30,7 +30,7 @@
 #' # Remove first dummy for each pair of dummy columns made
 #' dummy_cols(crime, select_columns = c("city", "year"),
 #'     remove_first_dummy = TRUE)
-dummy_cols_V2 <- function(.data,
+dummy_cols <- function(.data,
                           select_columns = NULL,
                           remove_first_dummy = FALSE) {
   
@@ -123,4 +123,4 @@ dummy_cols_V2 <- function(.data,
 #' # Remove first dummy for each pair of dummy columns made
 #' dummy_cols(crime, select_columns = c("city", "year"),
 #'     remove_first_dummy = TRUE)
-dummy_columns <- dummy_cols_V2
+dummy_columns <- dummy_cols


### PR DESCRIPTION
Here is the profile of the two function on 1e6 rows and 4 columns of data:

![1e6](https://user-images.githubusercontent.com/28139045/36336354-e0d4fe5e-133b-11e8-85d4-413cc9d42fe9.PNG)
Please note the memory usage: chmatch is faster and consuming less. I don't quick understand the last step that change the data.table back to data.frame. Those two objects are compatible. If users don't use data.table, I guess they don't fill the difference between the two objects. 

![profile 2](https://user-images.githubusercontent.com/28139045/36336331-a4272590-133b-11e8-9cec-db5440ce7db3.PNG)

without changing back to data.frame
![profile 1](https://user-images.githubusercontent.com/28139045/36336333-a45f7af8-133b-11e8-91e3-97d81bb6b944.PNG)


Here are the test codes:

```
rm(list=ls())
gc()
library(data.table)
library(pryr)
source("./R/dummy_cols.R")
source("./R/dummy_cols_V2.R")

n=1e6
m = 6
set.seed(1)
dat = data.table(
  A=sample(LETTERS[11:(11+m)], size=n, replace=TRUE),
  B=sample(letters[1:m], size=n, replace=TRUE ),
  C=sample(n,n),
  D=sample(factor(letters[1:m]), size=n, replace=TRUE )
)

dat2 = copy(dat)

object_size(dat)



system.time(dummy_cols(dat))
# mem_change(dummy_cols(dat))


system.time(dummy_cols_V2(dat2))
# mem_change(dummy_cols_V2(dat2))


all.equal(dat, dat2)   # TRUE
identical(dat, dat2)   # TRUE


# for profile , run seperately with fresh start
# invisible(dummy_cols(dat))
# invisible(dummy_cols_V2(dat2))
```