### PR TITLE
Add option to omit colname prefix when only one column is recoded

### DIFF
--- a/man/dummy_cols.Rd
+++ b/man/dummy_cols.Rd
@@ -11,7 +11,8 @@ dummy_cols(
   remove_most_frequent_dummy = FALSE,
   ignore_na = FALSE,
   split = NULL,
-  remove_selected_columns = FALSE
+  remove_selected_columns = FALSE,
+  omit_colname_prefix = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ then a split value of "," this row would have a value of 1 for both the cat
 and dog dummy columns.}
 
 \item{remove_selected_columns}{If TRUE (not default), removes the columns used to generate the dummy columns.}
+
+\item{omit_colname_prefix}{If TRUE (not default) and `length(select_columns) == 1`, omit pre-pending the
+name of `select_columns` to the names of the newly generated dummy columns}
 }
 \value{
 A data.frame (or tibble or data.table, depending on input data type) with

--- a/man/dummy_columns.Rd
+++ b/man/dummy_columns.Rd
@@ -11,7 +11,8 @@ dummy_columns(
   remove_most_frequent_dummy = FALSE,
   ignore_na = FALSE,
   split = NULL,
-  remove_selected_columns = FALSE
+  remove_selected_columns = FALSE,
+  omit_colname_prefix = FALSE
 )
 }
 \arguments{
@@ -38,6 +39,9 @@ then a split value of "," this row would have a value of 1 for both the cat
 and dog dummy columns.}
 
 \item{remove_selected_columns}{If TRUE (not default), removes the columns used to generate the dummy columns.}
+
+\item{omit_colname_prefix}{If TRUE (not default) and `length(select_columns) == 1`, omit pre-pending the
+name of `select_columns` to the names of the newly generated dummy columns}
 }
 \description{
 dummy_columns() quickly creates dummy (binary) columns from character and

--- a/tests/testthat/test-omit-colname-prefix.R
+++ b/tests/testthat/test-omit-colname-prefix.R
@@ -1,0 +1,70 @@
+sample_data <-
+  structure(
+    list(
+      colA = c("a", "a", "a", "b", "b", "c", "c", "c",
+               "c", "c"),
+      colB = c(1, 1, 1, 2, 2, 3, 3, 3, 3, 3),
+      colC = c(
+        "val1",
+        "val2",
+        "val3",
+        "val1",
+        "val2",
+        "val7",
+        "val2",
+        "val4",
+        "val6",
+        "val8"
+      )
+    ),
+    row.names = c(NA, -10L),
+    class = c("tbl_df", "tbl",
+              "data.frame")
+  )
+
+test_that("omit_colname_prefix works", {
+  expect_named(
+    dummy_cols(
+      sample_data,
+      c("colC"),
+      remove_selected_columns = TRUE,
+      omit_colname_prefix = TRUE
+    ),
+    c(
+      "colA",
+      "colB",
+      "val1",
+      "val2",
+      "val3",
+      "val4",
+      "val6",
+      "val7",
+      "val8"
+    )
+  )
+})
+
+test_that("omit_colname_prefix does not remove prefix when >1 select_columns",
+          {
+            expect_named(
+              dummy_cols(
+                sample_data,
+                c("colB", "colC"),
+                remove_selected_columns = TRUE,
+                omit_colname_prefix = TRUE
+              ),
+              c(
+                "colA",
+                "colB_1",
+                "colB_2",
+                "colB_3",
+                "colC_val1",
+                "colC_val2",
+                "colC_val3",
+                "colC_val4",
+                "colC_val6",
+                "colC_val7",
+                "colC_val8"
+              )
+            )
+          })


### PR DESCRIPTION
Hey @jacobkap,

We've been using your very nice and fast package for creating dummy variables. In most of our use cases, we needed to transform one variable, and ended up having to remove the colname prefix downstream. We thought it might be a nice feature to allow for this omitting of the prefix directly by `dummy_cols`. Only if recoding one column, of course. This is something the user would have to opt into. I made this amendment to the function and wrote a couple of unit tests to ensure it does not interfere with existing functionality. 

Have a look at this if you have a chance. 